### PR TITLE
Updated the base_url for all images

### DIFF
--- a/lib/ruby-tmdb3/tmdb.rb
+++ b/lib/ruby-tmdb3/tmdb.rb
@@ -14,7 +14,7 @@ class Tmdb
   # TODO: Should be refreshed and cached from API 
   CONFIGURATION = DeepOpenStruct.load({ "images" =>
                     { 
-                      "base_url"        => "http://cf2.imgobject.com/t/p/", 
+                      "base_url"        => "http://image.tmdb.org/t/p/", 
                       "posters_sizes"   => ["w92", "w154", "w185", "w342", "w500", "original"],
                       "backdrops_sizes" => ["w300", "w780", "w1280", "original"],
                       "profiles_sizes"  => ["w45", "w185", "h632", "original"],


### PR DESCRIPTION
http://imgobject.com was decommissioned in late 2012. Since the last weekend the domain is down. So the URLs won´t work anymore.

For more information check out my conversation with @themoviedb on Twitter: https://twitter.com/themoviedb/status/568519156502368258
